### PR TITLE
ReadKey method incorrect reading from file

### DIFF
--- a/VocabLib/keys2.cpp
+++ b/VocabLib/keys2.cpp
@@ -239,7 +239,9 @@ int ReadKeys(FILE *fp, short int **keys, keypt_t **info)
 	// short int *d = new short int[128];
 	float x, y, scale, ori;
 
-	if (fscanf(fp, "%f %f %f %f\n", &y, &x, &scale, &ori) != 4) {
+	//int cake = fscanf(fp, "%f %f\n", &y, &x);	
+	int cake = fscanf(fp, "%f %f %f %f\n", &y, &x, &scale, &ori);
+	if (cake != 4) {
 	    printf("Invalid keypoint file format.");
 	    return 0;
 	}
@@ -251,23 +253,27 @@ int ReadKeys(FILE *fp, short int **keys, keypt_t **info)
             (*info)[i].orient = ori;
         }
         
-	char buf[1024];
+	char buffer[1024];
+	char *buf = buffer;
+	fgets(buf, 1024, fp);
+	int offset;
 	for (int line = 0; line < 7; line++) {
-	    fgets(buf, 1024, fp);
-
+	  
 	    if (line < 6) {
 		sscanf(buf, 
 		       "%hu %hu %hu %hu %hu %hu %hu %hu %hu %hu "
-		       "%hu %hu %hu %hu %hu %hu %hu %hu %hu %hu", 
+		       "%hu %hu %hu %hu %hu %hu %hu %hu %hu %hu %n", 
 		       p+0, p+1, p+2, p+3, p+4, p+5, p+6, p+7, p+8, p+9, 
 		       p+10, p+11, p+12, p+13, p+14, 
-		       p+15, p+16, p+17, p+18, p+19);
-
+		       p+15, p+16, p+17, p+18, p+19, &offset);
+		
 		p += 20;
+		buf += offset;
 	    } else {
 		sscanf(buf, 
 		       "%hu %hu %hu %hu %hu %hu %hu %hu",
 		       p+0, p+1, p+2, p+3, p+4, p+5, p+6, p+7);
+		
 		p += 8;
 	    }
 	}
@@ -349,7 +355,7 @@ int ReadKeysGzip(gzFile fp, short int **keys, keypt_t **info)
 		       "%hu %hu %hu %hu %hu %hu %hu %hu %hu %hu", 
 		       p+0, p+1, p+2, p+3, p+4, p+5, p+6, p+7, p+8, p+9, 
 		       p+10, p+11, p+12, p+13, p+14, 
-		       p+15, p+16, p+17, p+18, p+19);
+		       p+15, p+16, p+17, p+18, p+19 );
 
 		p += 20;
 	    } else {

--- a/VocabLib/keys2.cpp
+++ b/VocabLib/keys2.cpp
@@ -239,9 +239,7 @@ int ReadKeys(FILE *fp, short int **keys, keypt_t **info)
 	// short int *d = new short int[128];
 	float x, y, scale, ori;
 
-	//int cake = fscanf(fp, "%f %f\n", &y, &x);	
-	int cake = fscanf(fp, "%f %f %f %f\n", &y, &x, &scale, &ori);
-	if (cake != 4) {
+	if (fscanf(fp, "%f %f %f %f\n", &y, &x, &scale, &ori) != 4) {
 	    printf("Invalid keypoint file format.");
 	    return 0;
 	}


### PR DESCRIPTION
It actually depends on how the file is created for reading the descriptor values. But if 128 values are consecutive then reading them initially in a buffer and then reading step by step into an array keeping track of how much is read from buffer is a better way.
